### PR TITLE
🐛 (admin trait) sanitizes classname to work w/ namespaces

### DIFF
--- a/src/SomeConfigAdmin.php
+++ b/src/SomeConfigAdmin.php
@@ -22,7 +22,8 @@ trait SomeConfigAdmin
             $class = $formData->ClassName;
             if (static::isConfig($class)) {
                 $config = $class::current_config();
-                $formData->Link .= "/EditForm/field/$class/item/$config->ID/edit";
+                $segment = $this->sanitiseClassName($class);
+                $formData->Link .= "/EditForm/field/$segment/item/$config->ID/edit";
             }
         }
         return $forms;


### PR DESCRIPTION
Turns backslashes to dashes in namespaced classes to ensure the Settings tab has the correct URL.