### PR TITLE
Update GridFieldDetailForm_ItemRequest_Extension for PHP 8.1

### DIFF
--- a/src/GridFieldDetailForm_ItemRequest_Extension.php
+++ b/src/GridFieldDetailForm_ItemRequest_Extension.php
@@ -19,7 +19,7 @@ class GridFieldDetailForm_ItemRequest_Extension extends Extension
             $linkPartsLength = count($linkParts);
             if ($linkPartsLength) {
                 $class = array_pop($linkParts);
-                if (SomeConfigAdmin::isConfig($class)) {
+                if (method_exists($class, 'current_config')) {
                     // Update the breadcrumbs
                     $controller = Controller::curr();
                     $items->last()->setField('Title', $firstLink->getField('Title'));


### PR DESCRIPTION
SomeConfigAdmin::isConfig throws a deprecation notice on PHP 8.1.  This replaces the line with the contents of that method, which should still work on older versions of PHP

Fixes issue #3 