### PR TITLE
 Fixed error when using custom DataObject URL segments

### DIFF
--- a/src/SomeConfigAdmin.php
+++ b/src/SomeConfigAdmin.php
@@ -22,8 +22,7 @@ trait SomeConfigAdmin
             $class = $formData->ClassName;
             if (static::isConfig($class)) {
                 $config = $class::current_config();
-                $segment = $this->sanitiseClassName($class);
-                $formData->Link .= "/EditForm/field/$segment/item/$config->ID/edit";
+                $formData->Link = $this->getCMSEditLinkForManagedDataObject($config);
             }
         }
         return $forms;


### PR DESCRIPTION
## The Problem
The ModelAdmin class supports defining custom URL segments via `$managed_models` like so:

```php
private static array $managed_models = [
    //...
    'custom-url-segment' => [
        'title' => 'Settings',
        'dataClass' => YourSomeConfigAdmin::class,
    ],
];
```
But this module assumes that the DataObject's sanitized class name is being used for the URL segment. Which causes the above configuration to error out with `I can't handle sub-URLs on class SilverStripe\Forms\FormRequestHandler.`

## The Solution
This pull request fixes that issue by replacing the link generation code in `SomeConfigAdmin::getManagedModelTabs()`with a call to ModalAdmin's built in `getCMSEditLinkForManagedDataObject()` method.

## Testing
I have tested this locally to ensure it still works with the minimal `$managed_models` configuration used in your ["How to use" documentation ](https://github.com/mooror/silverstripe-someconfig?tab=readme-ov-file#how-to-use).